### PR TITLE
APPSEC-2105: Add Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,13 @@
+name: Semgrep
+on:
+  pull_request: {}
+  push:
+    branches:
+    - master
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch: {}
+jobs:
+  semgrep:
+    uses: gemini/semgrep/.github/workflows/semgrep-base.yml@main
+    secrets: inherit


### PR DESCRIPTION
This repo has been identified as a sensitive repository by the AppSec team, as such we want to run Semgrep on this repo. Semgrep will scan new pulls requests using a baseline rule set and report findings into the Semgrep dashboard. At some point in the future after the team feels confident in the findings reported, the AppSec team will enable PR annotations which will cause Semgrep flag these findings in the PR view. Currently, this change should have no change on development lifecycle.